### PR TITLE
Implement confirmation dialog for transaction deletion

### DIFF
--- a/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/model/EditTransactionDialog.kt
+++ b/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/model/EditTransactionDialog.kt
@@ -1,0 +1,5 @@
+package com.felixjhonata.trackney.add_edit_transaction.model
+
+sealed interface EditTransactionDialog: AddEditTransactionDialog {
+    object ConfirmDeleteDialog: EditTransactionDialog
+}

--- a/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/model/EditTransactionUserEvent.kt
+++ b/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/model/EditTransactionUserEvent.kt
@@ -3,4 +3,5 @@ package com.felixjhonata.trackney.add_edit_transaction.model
 sealed interface EditTransactionUserEvent: AddEditTransactionUserEvent {
     object EditTransactionButtonPressed: EditTransactionUserEvent
     object DeleteTransactionButtonPressed: EditTransactionUserEvent
+    object DeleteTransactionConfirmed: EditTransactionUserEvent
 }

--- a/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/view/AddEditTransactionPageContent.kt
+++ b/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/view/AddEditTransactionPageContent.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -52,6 +53,7 @@ import com.felixjhonata.trackney.add_edit_transaction.model.AddEditTransactionDi
 import com.felixjhonata.trackney.add_edit_transaction.model.AddEditTransactionUiState
 import com.felixjhonata.trackney.add_edit_transaction.model.AddEditTransactionUserEvent
 import com.felixjhonata.trackney.add_edit_transaction.model.AddTransactionUserEvent
+import com.felixjhonata.trackney.add_edit_transaction.model.EditTransactionDialog
 import com.felixjhonata.trackney.add_edit_transaction.model.EditTransactionUserEvent
 import com.felixjhonata.trackney.add_edit_transaction.model.ModifyTransactionType
 import com.felixjhonata.trackney.shared.model.TransactionType
@@ -305,7 +307,7 @@ private fun FooterButton(
 }
 
 @Composable
-fun DateDialog(
+private fun DateDialog(
     initialSelectedDate: Long,
     onDismiss: () -> Unit,
     showTimePicker: (LocalDate) -> Unit,
@@ -342,7 +344,7 @@ fun DateDialog(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TimeDialog(
+private fun TimeDialog(
     initialHour: Int,
     initialMinute: Int,
     onDismiss: () -> Unit,
@@ -374,6 +376,35 @@ fun TimeDialog(
     ) {
         TimePicker(timePickerState)
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ConfirmDeleteTransactionDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AlertDialog(
+        modifier = modifier,
+        onDismissRequest = onDismiss,
+        title = {
+            Text("Are you sure?")
+        },
+        text = {
+            Text("You are going to delete the transaction record permanently")
+        },
+        confirmButton = {
+            Button(onConfirm) {
+                Text("Delete")
+            }
+        },
+        dismissButton = {
+            OutlinedButton(onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }
 
 @Composable
@@ -430,6 +461,12 @@ fun AddEditTransactionPageContent(
                             )
                         )
                     }
+                )
+            }
+            EditTransactionDialog.ConfirmDeleteDialog -> {
+                ConfirmDeleteTransactionDialog(
+                    { onUserEvent(AddEditTransactionUserEvent.DismissDialog) },
+                    { onUserEvent(EditTransactionUserEvent.DeleteTransactionConfirmed) }
                 )
             }
         }

--- a/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/viewmodel/AddEditTransactionViewModel.kt
+++ b/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/viewmodel/AddEditTransactionViewModel.kt
@@ -48,7 +48,7 @@ abstract class AddEditTransactionViewModel(
         }
     protected var categories: List<Category> = emptyList()
 
-    protected val _uiState = MutableStateFlow(
+    private val _uiState = MutableStateFlow(
         AddEditTransactionUiState(
             dateTime = LocalDateTime.now().format(formatter)
         )
@@ -120,6 +120,12 @@ abstract class AddEditTransactionViewModel(
         else -> null
     }
 
+    protected fun showDialog(dialog: AddEditTransactionDialog) {
+        _uiState.update {
+            it.copy(dialog = dialog)
+        }
+    }
+
     protected abstract fun handleChildrenUserEvent(event: AddEditTransactionUserEvent)
 
     fun onUserEvent(event: AddEditTransactionUserEvent) {
@@ -151,25 +157,19 @@ abstract class AddEditTransactionViewModel(
             }
 
             AddEditTransactionUserEvent.DismissDialog -> {
-                _uiState.update {
-                    it.copy(dialog = AddEditTransactionDialog.None)
-                }
+                showDialog(AddEditTransactionDialog.None)
             }
 
             AddEditTransactionUserEvent.ShowDatePickerDialog -> {
-                _uiState.update {
-                    it.copy(dialog = AddEditTransactionDialog.DatePickerDialog)
-                }
+                showDialog(AddEditTransactionDialog.DatePickerDialog)
             }
 
             is AddEditTransactionUserEvent.ShowTimePickerDialog -> {
-                _uiState.update {
-                    it.copy(
-                        dialog = AddEditTransactionDialog.TimePickerDialog(
-                            event.selectedDate
-                        )
+                showDialog(
+                    AddEditTransactionDialog.TimePickerDialog(
+                        event.selectedDate
                     )
-                }
+                )
             }
 
             is AddEditTransactionUserEvent.ChangeDateTime -> {

--- a/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/viewmodel/EditTransactionViewModel.kt
+++ b/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/viewmodel/EditTransactionViewModel.kt
@@ -1,7 +1,9 @@
 package com.felixjhonata.trackney.add_edit_transaction.viewmodel
 
 import androidx.lifecycle.viewModelScope
+import com.felixjhonata.trackney.add_edit_transaction.model.AddEditTransactionDialog
 import com.felixjhonata.trackney.add_edit_transaction.model.AddEditTransactionUserEvent
+import com.felixjhonata.trackney.add_edit_transaction.model.EditTransactionDialog
 import com.felixjhonata.trackney.add_edit_transaction.model.EditTransactionUserEvent
 import com.felixjhonata.trackney.shared.model.annotations.IoDispatchers
 import com.felixjhonata.trackney.shared.model.entity.Transaction
@@ -62,8 +64,9 @@ class EditTransactionViewModel @Inject constructor(
     }
 
     private fun deleteTransaction() {
+        showDialog(AddEditTransactionDialog.None)
         val transaction = currentTransaction ?: return
-        
+
         viewModelScope.launch(ioDispatchers) {
             try {
                 transactionRepository.deleteTransaction(transaction)
@@ -74,11 +77,16 @@ class EditTransactionViewModel @Inject constructor(
         }
     }
 
+    private fun showConfirmDeleteDialog() {
+        showDialog(EditTransactionDialog.ConfirmDeleteDialog)
+    }
+
     override fun handleChildrenUserEvent(event: AddEditTransactionUserEvent) {
         (event as? EditTransactionUserEvent)?.let { editEvent ->
             when(editEvent) {
                 EditTransactionUserEvent.EditTransactionButtonPressed -> editTransaction()
-                EditTransactionUserEvent.DeleteTransactionButtonPressed -> deleteTransaction()
+                EditTransactionUserEvent.DeleteTransactionButtonPressed -> showConfirmDeleteDialog()
+                EditTransactionUserEvent.DeleteTransactionConfirmed -> deleteTransaction()
             }
         }
     }

--- a/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/viewmodel/EditTransactionViewModel.kt
+++ b/app/src/main/java/com/felixjhonata/trackney/add_edit_transaction/viewmodel/EditTransactionViewModel.kt
@@ -78,6 +78,7 @@ class EditTransactionViewModel @Inject constructor(
     }
 
     private fun showConfirmDeleteDialog() {
+        if (currentTransaction == null) return
         showDialog(EditTransactionDialog.ConfirmDeleteDialog)
     }
 


### PR DESCRIPTION
This pull request introduces a confirmation dialog before deleting a transaction in the Edit Transaction flow. The main changes include adding a new dialog and user event, updating the UI to display the confirmation dialog, and refactoring the ViewModel logic to support this feature.

**Edit Transaction Delete Confirmation Feature:**

* Added a new sealed interface `EditTransactionDialog` with a `ConfirmDeleteDialog` object to represent the delete confirmation dialog (`EditTransactionDialog.kt`).
* Introduced a new user event `DeleteTransactionConfirmed` to handle confirmation actions (`EditTransactionUserEvent.kt`).

**UI Updates:**

* Implemented `ConfirmDeleteTransactionDialog` composable using `AlertDialog`, and updated `AddEditTransactionPageContent` to display this dialog when required (`AddEditTransactionPageContent.kt`). [[1]](diffhunk://#diff-ef47305c0453b98433d23e57340e20d646e56284af4f457b00985603175652a8R381-R409) [[2]](diffhunk://#diff-ef47305c0453b98433d23e57340e20d646e56284af4f457b00985603175652a8R466-R471)

**ViewModel Logic and Refactoring:**

* Refactored dialog state management in `AddEditTransactionViewModel` by adding a reusable `showDialog` method and updating dialog state changes to use it (`AddEditTransactionViewModel.kt`). [[1]](diffhunk://#diff-2e06e521f9e323db58d15c78fae83054ea63d5edca4ea68e26fa844d85c08f6eR123-R128) [[2]](diffhunk://#diff-2e06e521f9e323db58d15c78fae83054ea63d5edca4ea68e26fa844d85c08f6eL154-L173)
* Updated `EditTransactionViewModel` to show the confirmation dialog instead of deleting immediately, and to handle the new confirmation event (`EditTransactionViewModel.kt`). [[1]](diffhunk://#diff-750c0e1e7554375ea0f4fb7207b11ca8141e6e7ac7f89c108ff2d55c494645d9R80-R89) [[2]](diffhunk://#diff-750c0e1e7554375ea0f4fb7207b11ca8141e6e7ac7f89c108ff2d55c494645d9R67)

These changes ensure that users must confirm before permanently deleting a transaction, improving safety and user experience.