### PR TITLE
techdebt: add kover dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.jetbrains.kotlin.serialization)
+    alias(libs.plugins.kotlinx.kover)
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlinx.kover) apply false
     id("com.google.devtools.ksp") version "2.3.6" apply false
     id("com.google.dagger.hilt.android") version "2.59.2" apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,4 +46,5 @@ kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinSerialization"}
+kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.8" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ lifecycleViewmodelNav3 = "2.11.0-beta01"
 kotlinSerialization = "2.2.21"
 kotlinxSerializationCore = "1.9.0"
 roomRuntime = "2.8.4"
+kover = "0.9.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -46,5 +47,6 @@ kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinSerialization"}
-kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.8" }
+kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+
 


### PR DESCRIPTION
Adds Kover dependency to the project to enable CLI-based test coverage check.

---

### 📝 Summary of Changes

1. **Build Configuration**:
   - Added Kover dependency version to `gradle/libs.versions.toml`.
   - Applied Kover plugin in the root `build.gradle.kts` file.
   - Applied Kover plugin in the `app/build.gradle.kts` module file.

---

### 🚀 Overall Effect
Enables generating and verifying test coverage reports via the command line using Kover, supporting CI/CD pipelines and automated code coverage checks.

---

### 📁 File Summary

#### 🆕 New Files (0)
*None*

#### 🛠️ Modified Files (3)
* `app/build.gradle.kts`
* `build.gradle.kts`
* `gradle/libs.versions.toml`

#### ❌ Removed Files (0)
* *None*
